### PR TITLE
This will help to end up with two layers of Docker image instead four and as there is no Entrypoint for the container we can change this from go build to go run

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -21,10 +21,9 @@
 # EXPOSE 8080
 
 # Refer - https://blog.golang.org/docker
-
 FROM golang:onbuild
-RUN go get github.com/gin-gonic/gin
-RUN go get github.com/jinzhu/gorm
-RUN go get github.com/lib/pq
-RUN go build main.go
+RUN go get github.com/gin-gonic/gin && \
+    go get github.com/jinzhu/gorm && \
+    go get github.com/lib/pq
+CMD ["go","run","main.go"]
 EXPOSE 8080


### PR DESCRIPTION
… layers